### PR TITLE
Replaces Rotciv with Colton in wizard academy

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/Academy.dmm
+++ b/_maps/RandomRuins/SpaceRuins/Academy.dmm
@@ -970,7 +970,7 @@
 /area/awaymission/academy/academyaft)
 "kV" = (
 /mob/living/simple_animal/hostile/wizard{
-	name = "Rotciv The Dented"
+	name = "Colton the Afterburner"
 	},
 /turf/open/floor/carpet,
 /area/awaymission/academy/academyaft)


### PR DESCRIPTION
Self explanatory title

:cl:  
tweak: Rotciv the Dented has been expelled from the wizard academy! In his place, Colton the Afterburner has transferred in.
/:cl:
